### PR TITLE
Correction of the target for appBase folder

### DIFF
--- a/src/org/jetbrains/idea/tomcat/server/TomcatLocalModel.java
+++ b/src/org/jetbrains/idea/tomcat/server/TomcatLocalModel.java
@@ -503,7 +503,7 @@ public class TomcatLocalModel extends TomcatServerModel {
       if (appBase == null) appBase = "";
 
       if (!FileUtil.isAbsolute(appBase)) {
-        appBase = new File(sourceBaseDirectoryPath, appBase).getAbsolutePath();
+        appBase = new File(baseDirectoryPath, appBase).getAbsolutePath();
       }
       localHost.setAttribute(TomcatConstants.APP_BASE_ATTR, appBase);
       localHost.setAttribute(AUTO_DEPLOY_ATTR, Boolean.TRUE.toString());


### PR DESCRIPTION
from sourceBaseDirectoryPath to baseDirectoryPath.
This enables IntelliJ to deploy the artifacts into the generated CATALINA_BASE\webapps folder instead of CATALINA_HOME\webapps.
This is important if you use multiple tomcat instances in parallel. Otherwise at the start of the second tomcat instance, the artifacts from the first instance are cleaned up.